### PR TITLE
本番環境でシステムエラーが発生したときにキャッシュをクリアさせる

### DIFF
--- a/src/Eccube/EventListener/ExceptionListener.php
+++ b/src/Eccube/EventListener/ExceptionListener.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Eccube\Util\CacheUtil;
 
 class ExceptionListener implements EventSubscriberInterface
 {
@@ -31,14 +32,20 @@ class ExceptionListener implements EventSubscriberInterface
      * @var Context
      */
     protected $requestContext;
+    
+    /**
+     * @var CacheUtil
+     */
+    private $cacheUtil;
 
     /**
      * ExceptionListener constructor.
      */
-    public function __construct(\Twig_Environment $twig, Context $requestContext)
+    public function __construct(\Twig_Environment $twig, Context $requestContext, CacheUtil $cacheUtil)
     {
         $this->twig = $twig;
         $this->requestContext = $requestContext;
+        $this->cacheUtil = $cacheUtil;
     }
 
     public function onKernelException(GetResponseForExceptionEvent $event)
@@ -91,6 +98,8 @@ class ExceptionListener implements EventSubscriberInterface
         }
 
         $event->setResponse(Response::create($content, $statusCode));
+        
+        $this->cacheUtil->clearCache();
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
本番環境でシステムエラーが発生(※1)したら管理画面にログイン出来なくなる場合があるので
システムエラーが発生したらキャッシュをクリアするようにしました。

※1ユーザー独自プラグインでプラグインを無効化した場合などで発生

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など

## 実装に関する補足(Appendix)
+ コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと

## テスト（Test)
+ テストを行っている範囲など、レビューアが安心できるような情報

## 相談（Discussion）
+ 相談したいことや意見を求めたいこと

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
