### PR TITLE
プラグインのエンティティを拡張できるようにする

### DIFF
--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -264,10 +264,12 @@ class Kernel extends BaseKernel
 
         foreach ($plugins as $code) {
             if (file_exists($pluginDir.'/'.$code.'/Entity')) {
-                $container->addCompilerPass(DoctrineOrmMappingsPass::createAnnotationMappingDriver(
-                    ['Plugin\\'.$code.'\\Entity'],
-                    ['%kernel.project_dir%/app/Plugin/'.$code.'/Entity']
-                ));
+                $paths = ['%kernel.project_dir%/app/Plugin/'.$code.'/Entity'];
+                $namespaces = ['Plugin\\'.$code.'\\Entity'];
+                $reader = new Reference('annotation_reader');
+                $driver = new Definition(AnnotationDriver::class, [$reader, $paths]);
+                $driver->addMethodCall('setTraitProxiesDirectory', [$projectDir.'/app/proxy/entity']);
+                $container->addCompilerPass(new DoctrineOrmMappingsPass($driver, $namespaces, []));
             }
         }
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
APP_ENV=prod、APP_DEBUG=0の場合、
プラグインのエンティティをEntityExtensionで拡張しても
拡張したエンティティのキャッシュが生成されず正常に動作しないので
キャッシュが生成されるように修正しました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
var/cache/prod/doctrine/orm内に拡張したエンティティのキャッシュが生成されていることを確認しました。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
