### PR TITLE
ログイン時のカートマージでカートが別れる場合のDoctrineのエラーを回避

### DIFF
--- a/src/Eccube/Entity/CartItem.php
+++ b/src/Eccube/Entity/CartItem.php
@@ -65,7 +65,7 @@ if (!class_exists('\Eccube\Entity\CartItem')) {
         /**
          * @var \Eccube\Entity\Cart
          *
-         * @ORM\ManyToOne(targetEntity="Eccube\Entity\Cart", inversedBy="CartItems")
+         * @ORM\ManyToOne(targetEntity="Eccube\Entity\Cart", inversedBy="CartItems", cascade={"persist"})
          * @ORM\JoinColumns({
          *   @ORM\JoinColumn(name="cart_id", referencedColumnName="id", onDelete="CASCADE")
          * })
@@ -91,7 +91,7 @@ if (!class_exists('\Eccube\Entity\CartItem')) {
         {
             return $this->id;
         }
-        
+
         /**
          * @param  integer  $price
          *

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -400,9 +400,7 @@ class CartService
             $this->entityManager->persist($Cart);
             foreach ($Cart->getCartItems() as $item) {
                 $this->entityManager->persist($item);
-                $this->entityManager->flush();
             }
-            $this->entityManager->persist($Cart);
             $this->entityManager->flush();
             $cartKeys[] = $Cart->getCartKey();
         }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

https://github.com/EC-CUBE/ec-cube/pull/4925#discussion_r594811660 のエラーを修正しました。

中途半端に `persist` した状態で `flush` するとエラーとなってしまうようでしたので、最後にまとめて `flush` するように変更しています。

`CartItem->Cart` に `cascade={"persist"}` の設定も追加しています。

## テスト（Test)

`EF03OrderCest: Ef0303-uc01-t01_購入フローでログインしたタイミングで複数カートになったらログイン後にカート画面に戻す` のテストが通ることを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
